### PR TITLE
Get infoblox deb package from ppa as a config

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -1,4 +1,17 @@
 options:
+  openstack-origin:
+    default: distro
+    type: string
+    description: |
+      Repository from which to install.  May be one of the following:
+      distro (default), ppa:somecustom/ppa, a deb url sources entry,
+      or a supported Cloud Archive release pocket.
+      Supported Cloud Archive sources include: cloud:precise-folsom,
+      cloud:precise-folsom/updates, cloud:precise-folsom/staging,
+      cloud:precise-folsom/proposed.
+      Note that updating this setting to a source that is known to
+      provide a later version of OpenStack will trigger a software
+      upgrade.
   cloud-data-center-id:
     type: string
     default: '1'

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -1,4 +1,9 @@
 options:
+  source:
+    default: ppa:canonical-infoblox/stable
+    type: string
+    description: |
+      Repository from which to install. Ex: ppa:canonical-infoblox/stable
   cloud-data-center-id:
     type: string
     default: '1'

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -1,17 +1,4 @@
 options:
-  openstack-origin:
-    default: distro
-    type: string
-    description: |
-      Repository from which to install.  May be one of the following:
-      distro (default), ppa:somecustom/ppa, a deb url sources entry,
-      or a supported Cloud Archive release pocket.
-      Supported Cloud Archive sources include: cloud:precise-folsom,
-      cloud:precise-folsom/updates, cloud:precise-folsom/staging,
-      cloud:precise-folsom/proposed.
-      Note that updating this setting to a source that is known to
-      provide a later version of OpenStack will trigger a software
-      upgrade.
   cloud-data-center-id:
     type: string
     default: '1'

--- a/src/lib/charm/openstack/infoblox.py
+++ b/src/lib/charm/openstack/infoblox.py
@@ -43,7 +43,7 @@ class InfobloxCharm(charms_openstack.charm.OpenStackCharm):
         log('Starting infoblox installation')
         installed = len(filter_installed_packages(self.packages)) == 0
         if not installed:
-            add_source('ppa:canonical-infoblox/stable')
+            add_source(config('source'))
             apt_update(fatal=True)
             apt_install(self.packages[0], fatal=True)
         if not leader_get('pool'):

--- a/src/lib/charm/openstack/infoblox.py
+++ b/src/lib/charm/openstack/infoblox.py
@@ -12,6 +12,13 @@ from charmhelpers.core.hookenv import (
     leader_set,
     leader_get,
 )
+from charmhelpers.fetch import (
+    apt_install,
+    apt_update,
+    filter_installed_packages,
+    add_source,
+)
+
 from charmhelpers.contrib.openstack.utils import (
     CompareOpenStackReleases,
     os_release,
@@ -34,10 +41,11 @@ class InfobloxCharm(charms_openstack.charm.OpenStackCharm):
 
     def install(self):
         log('Starting infoblox installation')
-        self.configure_source()
-        # and do the actual install
-        super(InfobloxCharm, self).install()
-
+        installed = len(filter_installed_packages(self.packages)) == 0
+        if not installed:
+            add_source('ppa:canonical-infoblox/stable')
+            apt_update(fatal=True)
+            apt_install(self.packages[0], fatal=True)
         if not leader_get('pool'):
             if is_leader():
                 leader_set({'pool': str(uuid.uuid4()),

--- a/src/lib/charm/openstack/infoblox.py
+++ b/src/lib/charm/openstack/infoblox.py
@@ -27,18 +27,16 @@ class InfobloxCharm(charms_openstack.charm.OpenStackCharm):
     release = 'queens'
 
     # List of packages to install for this charm
-    packages = ['']
+    packages = ['python-networking-infoblox']
 
-    def install(self, neutron=False):
+    default_service = 'infoblox-ipam-agent'
+
+
+    def install(self):
         log('Starting infoblox installation')
-        if neutron:
-            subprocess.check_call(
-                ['wget', 'https://github.com/mskalka/networking-infoblox-'
-                'deb/raw/master/networking-infoblox_12.0.0_amd64.deb'])
-            subprocess.check_call(
-                ['dpkg', '-i', 'networking-infoblox_12.0.0_amd64.deb'])
-            subprocess.check_call(
-                ['service', 'infoblox-ipam-agent', 'restart'])
+        self.configure_source()
+        # and do the actual install
+        super(InfobloxCharm, self).install()
 
         if not leader_get('pool'):
             if is_leader():
@@ -52,7 +50,7 @@ class InfobloxCharm(charms_openstack.charm.OpenStackCharm):
         username = config('admin-user-name')
         password = config('admin-password')
         views = config('network-views')
-        subprocess.check_call(['service', 'infoblox-ipam-agent', 'restart'])
+        subprocess.check_call(['systemctl', 'restart','infoblox-ipam-agent'])
         subprocess.check_call(
             ['create_ea_defs', '-u', username, '-p', password, '-pnv', views])
 

--- a/src/reactive/infoblox_handlers.py
+++ b/src/reactive/infoblox_handlers.py
@@ -27,8 +27,7 @@ use_defaults('update-status')
 @reactive.when_not('infoblox.installed')
 def install_infoblox():
     with provide_charm_instance() as charm_class:
-        charm_class.install(
-            neutron=reactive.flags.is_flag_set('neutron.connected'))
+        charm_class.install()
     reactive.set_state('infoblox.installed')
 
 


### PR DESCRIPTION
src code of the deb package is in : https://code.launchpad.net/~canonical-infoblox/+git
needs to put this ppa as a config for the charm: ppa:canonical-infoblox/stable until we push those packages to the UCA.