### PR TITLE
Update tox and requirements to enable basic testability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,6 @@
 # one-off, please don't.  Intead, consult #openstack-charms and ask about
 # requirements management in charms via bot-control.  Thank you.
 #
-# Lint and unit test requirements
-flake8>=2.2.4,<=2.4.1
-os-testr>=0.4.1
-requests>=2.18.4
-charms.reactive
-mock>=1.2
-nose>=1.3.7
-coverage>=3.6
-git+https://github.com/openstack/charms.openstack.git#egg=charms.openstack
+# Build requirements
+charm-tools>=2.4.4
+simplejson

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -8,12 +8,12 @@ skipsdist = True
 [testenv]
 setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
-         AMULET_SETUP_TIMEOUT=2700
+         AMULET_SETUP_TIMEOUT=5400
 whitelist_externals = juju
-passenv = HOME TERM AMULET_*
+passenv = HOME TERM AMULET_* CS_*
 deps = -r{toxinidir}/test-requirements.txt
 install_command =
-  pip install --allow-unverified python-apt {opts} {packages}
+  pip install {opts} {packages}
 
 [testenv:pep8]
 basepython = python2.7
@@ -35,7 +35,7 @@ commands =
 # Run a specific test as an Amulet smoke test (expected to always pass)
 basepython = python2.7
 commands =
-    bundletester -vl DEBUG -r json -o func-results.json gate-basic-xenial-mitaka --no-destroy
+    bundletester -vl DEBUG -r json -o func-results.json gate-basic-xenial-queens --no-destroy
 
 [testenv:func27-dfs]
 # Run all deploy-from-source tests which are +x (may not always pass!)

--- a/test-generate-requirements.txt
+++ b/test-generate-requirements.txt
@@ -1,5 +1,0 @@
-# Requirements for generating a charm
-charm-tools
-simple-json
-jinja2
-git+https://github.com/openstack-charmers/charm-templates-openstack.git

--- a/tox.ini
+++ b/tox.ini
@@ -3,37 +3,26 @@
 # within individual charm repos.
 [tox]
 skipsdist = True
-envlist = pep8,py34,py35
-skip_missing_interpreters = True
+envlist = pep8,py3
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
          TERM=linux
-         LAYER_PATH={toxinidir}/layers
-         INTERFACE_PATH={toxinidir}/interfaces
          JUJU_REPOSITORY={toxinidir}/build
-passenv = http_proxy https_proxy USER
+passenv = http_proxy https_proxy INTERFACE_PATH LAYER_PATH
 install_command =
   pip install {opts} {packages}
 deps =
     -r{toxinidir}/requirements.txt
 
 [testenv:build]
-basepython = python2.7
+basepython = python3
 commands =
     charm-build --log-level DEBUG -o {toxinidir}/build src {posargs}
 
-[testenv:py27]
-basepython = python2.7
-# Reactive source charms are Python3-only, but a py27 unit test target
-# is required by OpenStack Governance.  Remove this shim as soon as
-# permitted.  http://governance.openstack.org/reference/cti/python_cti.html
-whitelist_externals = true
-commands = true
-
-[testenv:py34]
-basepython = python3.4
+[testenv:py3]
+basepython = python3
 deps = -r{toxinidir}/test-requirements.txt
 commands = ostestr {posargs}
 
@@ -42,12 +31,18 @@ basepython = python3.5
 deps = -r{toxinidir}/test-requirements.txt
 commands = ostestr {posargs}
 
+[testenv:py36]
+basepython = python3.6
+deps = -r{toxinidir}/test-requirements.txt
+commands = ostestr {posargs}
+
 [testenv:pep8]
-basepython = python3.5
+basepython = python3
 deps = -r{toxinidir}/test-requirements.txt
 commands = flake8 {posargs} src unit_tests
 
 [testenv:venv]
+basepython = python3
 commands = {posargs}
 
 [flake8]


### PR DESCRIPTION
The changes in this PR are necessary in order to be able to execute basic tests such as lint, pep8, charm-proof or charm build.  This does not resolve any existing issues other than framework cleanup.